### PR TITLE
User specific dms

### DIFF
--- a/Application/Frontend/components/Messaging/MessagingInterface.tsx
+++ b/Application/Frontend/components/Messaging/MessagingInterface.tsx
@@ -265,7 +265,7 @@ export function MessagingInterface({ sender, receiver, privateChat, onMessageExc
               <Group grow>
                 <Textarea
                     ref={inputBoxRef}
-                    placeholder="Message @user2"
+                    placeholder={`Message @${receiver}`}
                     autosize
                     minRows={1}
                     maxRows={10}

--- a/Application/Frontend/pages/accord.tsx
+++ b/Application/Frontend/pages/accord.tsx
@@ -26,9 +26,8 @@ import { Chat } from "@/components/Messaging/Chat";
 import React, { useState } from 'react';
 import { ChatProvider } from "@/contexts/chatContext";
 import { DirectMessageModal } from '@/components/Messaging/DirectMessageModal';
-import { UserButton } from "@clerk/nextjs";
 import classes from "@/components/tabstyling.module.css";
-import { UserProfile } from '@clerk/nextjs';
+import { useUser, UserButton, UserProfile } from '@clerk/nextjs';
 
 /**
  * Represents the central structure of the application interface, organizing the layout into
@@ -50,6 +49,8 @@ export default function Accord() {
   const [privateMode, setPrivateMode] = useState(true);
   const [chatStarted, setChatStarted] = useState(false);
 
+  const { user } = useUser();
+
   // IMPORTANT: We are hardcoding user1 as the user who is currently signed in.
   // In the final implementation, we would extract the sender from the user's session via a site-wide authentication provider.
   // Receiver would come from clicking on a friend in the dropdown that appears when clicking the "Send DM" button.
@@ -57,8 +58,7 @@ export default function Accord() {
   // Every time we click on a friend who we want to chat with, we check if they are currently subscribed to the chat channel, and if not, we subscribe them.
   // This involves writing a query to the database to check who is in this chat (i.e. who is subscribed to this channel).
   // As for example the sender of this chat will be user1 and the receiver will be user2, but this will be flipped for user2 as they will be the sender in that case.
-  const sender = "user1";
-  const receiver = "user2";
+  const sender = user?.username;
 
   // note: we are manually handling the currently selected tab via states
   const handleTabSelection = (value: string) => setActiveView(value);
@@ -146,17 +146,16 @@ export default function Accord() {
             <Tabs.Panel value="profile">
                   <div className="general-container">
                   <UserProfile/>
-    </div>
-              
+        </div>
             </Tabs.Panel>}
-            {activeView === 'message' && (
+            {/* {activeView === 'message' && (
               <Chat
                 sender={sender}
                 receiver={receiver}
                 privateChat={privateMode}
                 onMessageExchange={onMessageExchange}  // Pass the handler to detect message exchanges
               />
-          )}
+          )} */}
           </AppShell.Main>
           <AppShell.Aside p="md" component={ScrollArea}>
             <Text>Servers</Text>


### PR DESCRIPTION
# Summary of Changes
- Made friends under `FriendsTab` clickable such that users can start conversations with specific users
- Temporarily disabled the "Send DM" button on the left sidebar until the button allows users to search up users they would like to message (even if they are not friends with them already)

# Changes Visualized

## You can see who I am currently signed in as (bottom left) and my specific friends
<img width="958" alt="Screenshot 2024-03-23 235604" src="https://github.com/ColinLefter/Accord/assets/68645918/4cd89d63-960d-4bed-988f-77a5427fe5d5">

## Messaging user 1 after clicking on them
<img width="956" alt="Screenshot 2024-03-23 235556" src="https://github.com/ColinLefter/Accord/assets/68645918/2265a425-e0ab-4a77-9a88-fc0e9416536c">

## Messaging user 2 after clicking on them
<img width="958" alt="Screenshot 2024-03-23 235608" src="https://github.com/ColinLefter/Accord/assets/68645918/cbc9a766-b528-412f-989b-b93522e37820">