### PR TITLE
Patched non-functional chat history

### DIFF
--- a/Application/Frontend/components/FriendsColumn/FooterProfile.tsx
+++ b/Application/Frontend/components/FriendsColumn/FooterProfile.tsx
@@ -29,11 +29,7 @@ export function FooterProfile() {
     <Card>
       <Group justify="space-between">
         <Group>
-          <AppLink href="/">
-            <Tooltip label="Profile">
-              <UserButton/>
-            </Tooltip>
-          </AppLink>
+          <UserButton/>
           <Text>{user?.username}</Text>
         </Group>
         <Tooltip label="User Settings">

--- a/Application/Frontend/components/FriendsColumn/FooterProfile.tsx
+++ b/Application/Frontend/components/FriendsColumn/FooterProfile.tsx
@@ -2,7 +2,7 @@ import { Avatar, Group, Card, Tooltip, Text, Stack, ActionIcon } from '@mantine/
 import { IconSettings } from '@tabler/icons-react';
 import { AppLink } from  "@/components/AppLink";
 import { useRouter } from 'next/router';
-import { useUser, UserProfile } from '@clerk/nextjs';
+import { useUser, UserButton, UserProfile } from '@clerk/nextjs';
 /**
  * FooterProfile renders a user profile component typically used in the footer area of the application.
  * It displays an avatar that links to the user's profile and provides a quick navigation option to view
@@ -31,7 +31,7 @@ export function FooterProfile() {
         <Group>
           <AppLink href="/">
             <Tooltip label="Profile">
-              <Avatar radius="xl"/>
+              <UserButton/>
             </Tooltip>
           </AppLink>
           <Text>{user?.username}</Text>

--- a/Application/Frontend/components/FriendsColumn/FriendsTab.tsx
+++ b/Application/Frontend/components/FriendsColumn/FriendsTab.tsx
@@ -28,11 +28,17 @@ import { Chat } from '@/components/Messaging/Chat';
     window.history.back();
   }
 
-export function FriendsTab(props: TextInputProps) {
+interface FriendsTabProps {
+  sender: string;
+  privateChat: boolean;
+  onMessageExchange: () => void; // Function type that doesn't take arguments and returns void
+}
+
+export function FriendsTab({sender, privateChat, onMessageExchange}: FriendsTabProps) {
     const router = useRouter();
     const [friendsList, setFriendsList] = useState<string[]>([]);
     const [searchQuery, setSearchQuery] = useState<string>('');
-    const [activeChat, setActiveChat] = useState(null); // State to manage active chat
+    const [activeChat, setActiveChat] = useState<string>(''); // State to manage active chat
     const { user } = useUser();
     
       /**
@@ -49,7 +55,6 @@ export function FriendsTab(props: TextInputProps) {
        */
       useEffect(() => {
         if (user) { // IMPORTANT: There is a slight delay in the user object being available after login, so we need to wait for it to not be null
-          console.log(user.id);
           const fetchData = async () => {
             try {
               const response = await fetch('/api/FriendsTab', {
@@ -57,12 +62,11 @@ export function FriendsTab(props: TextInputProps) {
                 headers: {
                   'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ id: user.id }), // Directly use user.username
+                body: JSON.stringify({ id: user.id })
               });
     
               if (response.ok) {
                 const data = await response.json();
-                console.log("My friends" + data.firstName);
                 setFriendsList(data.friendsList);
               } else {
                 console.error('Failed to fetch friend list');
@@ -77,21 +81,20 @@ export function FriendsTab(props: TextInputProps) {
       }, [user]); // Dependency array includes user, so effect runs when user changes
 
           // Filter friendsList based on search query
-    const filteredFriendsList = friendsList.filter((friend) =>
-      friend.toLowerCase().includes(searchQuery.toLowerCase())
+    const filteredFriendsList = friendsList.filter((friendUsername) =>
+      friendUsername.toLowerCase().includes(searchQuery.toLowerCase()) // This means that the search is case-insensitive
     );
 
-    const handleFriendClick = (friend: any) => {
-      // Assuming 'friend' can be used as 'receiver' in Chat
-      setActiveChat(friend);
+    const handleFriendClick = (friendUsername: string) => {
+      setActiveChat(friendUsername);
     };
 
     if (activeChat && user?.id) { // Ensure both activeChat and user.id are defined
       return <Chat 
-          sender={user.username as any}
-          receiver={activeChat} // The receiver is now the friend we clicked on
-          privateChat={true}
-          onMessageExchange={() => {}}
+          sender={sender}
+          receiver={activeChat} // The receiver is now the friend we clicked on.
+          privateChat={privateChat}
+          onMessageExchange={onMessageExchange}
       />;
   }
     
@@ -123,11 +126,11 @@ export function FriendsTab(props: TextInputProps) {
                 All friends
             </Text>
             {/** Users that are in the friendsList*/}
-            {filteredFriendsList.map((friend, index) => (
-                <Paper color="black" shadow="xs" p="xs" radius="md" key={`friend-${index}`} onClick={() => handleFriendClick(friend)}>
+            {filteredFriendsList.map((friendUsername, index) => (
+                <Paper color="black" shadow="xs" p="xs" radius="md" key={`friend-${index}`} onClick={() => handleFriendClick(friendUsername)}>
                     <Group py="10">
                         <Avatar alt={`Friend ${index + 1}`} radius="xl"/>
-                        <Text size="sm">{friend}</Text>
+                        <Text size="sm">{friendUsername}</Text>
                     </Group>
                 </Paper>
             ))}

--- a/Application/Frontend/components/Messaging/Message.tsx
+++ b/Application/Frontend/components/Messaging/Message.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Group, Stack, Avatar, Text } from '@mantine/core';
+import { useUser } from '@clerk/nextjs';
+import { useState, useEffect } from 'react';
 
 interface MessageProps {
   username: string,
@@ -29,11 +31,22 @@ interface MessageProps {
  * @returns {JSX.Element} The rendered Message component.
  */
 export function Message({ username, message, firstMessage, date }: MessageProps) {
+  const { user } = useUser();
+
+  const [userProfileURL, setUserProfileURL] = useState<string>(''); 
+
+  useEffect(() => {
+    if (user && user.imageUrl) {
+      // Set sender to user's username if user exists and username is not null/undefined
+      setUserProfileURL(user.imageUrl);
+    }
+  }, [user]); // Dependency array ensures this runs whenever `user` changes
+
   return (
     <Group gap="xs">
       {/* Render the Avatar only if firstMessage is present; otherwise, render an empty space */}
       {firstMessage ? (
-        <Avatar radius="xl" />
+        <Avatar radius="xl" src={userProfileURL} />
       ) : (
         <div style={{ width: 38 }} /> // Adjusted width to match the Avatar size
       )}

--- a/Application/Frontend/components/Messaging/MessagingInterface.tsx
+++ b/Application/Frontend/components/Messaging/MessagingInterface.tsx
@@ -5,7 +5,6 @@ import { Stack, Group, Container, Flex, Textarea, Button, ScrollArea } from '@ma
 import React, { useEffect, useState, useRef } from 'react';
 import { useChannel } from "ably/react";
 import { useChat } from "@/contexts/chatContext";
-import * as Ably from 'ably';
 
 export interface Message {
   username: string,

--- a/Application/Frontend/components/Messaging/MessagingInterface.tsx
+++ b/Application/Frontend/components/Messaging/MessagingInterface.tsx
@@ -98,8 +98,10 @@ export function MessagingInterface({ sender, receiver, privateChat, onMessageExc
         if (data.messageHistory && data.messageHistory.length > 0) {
           setReceivedMessages(data.messageHistory);
         }
-      } else {
-        console.error('Failed to fetch message history from MongoDB.');
+      } else if (response.status === 404) {
+        console.error("Chat history not found");
+      } else if (response.status === 500) {
+        console.error("Error fetching message history");
       }
     } catch (error) {
       console.error('Error fetching message history from MongoDB:', error);
@@ -151,6 +153,7 @@ export function MessagingInterface({ sender, receiver, privateChat, onMessageExc
   
       // IMPORTANT: Every time a new message is sent, we are also overwriting the chat history in the database.
       // We are doing this to ensure that the chat history is always up to date.
+      console.log("Is chat private?", privateChat);
       if (!privateChat) {
         try {
           fetch('/api/update-message-history', {
@@ -161,8 +164,8 @@ export function MessagingInterface({ sender, receiver, privateChat, onMessageExc
             body: JSON.stringify({
               channelKey,
               messageHistory: updatedHistory,
-              owner: sender, // hard-coded until we implement site-wide user authentication
-              members: [sender, receiver] // hard-coded until we implement site-wide user authentication
+              owner: sender,
+              members: [sender, receiver]
             }),
           });
         } catch (error) {

--- a/Application/Frontend/pages/accord.tsx
+++ b/Application/Frontend/pages/accord.tsx
@@ -23,7 +23,7 @@ import { FriendsTab } from "@/components/FriendsColumn/FriendsTab";
 import { ColorSchemeToggle } from "@/components/ColorSchemeToggle/ColorSchemeToggle";
 import { FooterProfile } from "@/components/FriendsColumn/FooterProfile";
 import { Chat } from "@/components/Messaging/Chat";
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ChatProvider } from "@/contexts/chatContext";
 import { DirectMessageModal } from '@/components/Messaging/DirectMessageModal';
 import classes from "@/components/tabstyling.module.css";
@@ -45,6 +45,9 @@ export default function Accord() {
   const [mobileOpened, { toggle: toggleMobile }] = useDisclosure();
   const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
   const [activeView, setActiveView] = useState('friends'); // Initialize with 'friends'
+  // Default is to just display no username. This will never be the case as you can't be here without an account.
+  // It just makes more sense to not show something like guestUser to indicate that the user must have an account if they have reached the shell.
+  const [sender, setSender] = useState<string>(''); 
 
   const [privateMode, setPrivateMode] = useState(true);
   const [chatStarted, setChatStarted] = useState(false);
@@ -58,7 +61,12 @@ export default function Accord() {
   // Every time we click on a friend who we want to chat with, we check if they are currently subscribed to the chat channel, and if not, we subscribe them.
   // This involves writing a query to the database to check who is in this chat (i.e. who is subscribed to this channel).
   // As for example the sender of this chat will be user1 and the receiver will be user2, but this will be flipped for user2 as they will be the sender in that case.
-  const sender = user?.username;
+  useEffect(() => {
+    if (user && user.username) {
+      // Set sender to user's username if user exists and username is not null/undefined
+      setSender(user.username);
+    }
+  }, [user]); // Dependency array ensures this runs whenever `user` changes
 
   // note: we are manually handling the currently selected tab via states
   const handleTabSelection = (value: string) => setActiveView(value);
@@ -99,7 +107,6 @@ export default function Accord() {
                   disabled={chatStarted}  // Disable the switch if the chat has started
                 />
                 <ColorSchemeToggle/>
-                <UserButton/>
               </Group>
             </Group>
           </AppShell.Header>
@@ -141,12 +148,12 @@ export default function Accord() {
             </AppShell.Section>
           </AppShell.Navbar>
           <AppShell.Main>
-            {activeView === 'friends' && <FriendsTab />}
+            {activeView === 'friends' && <FriendsTab sender={sender} privateChat={privateMode} onMessageExchange={onMessageExchange} />}
             {activeView === 'profile' &&
             <Tabs.Panel value="profile">
-                  <div className="general-container">
-                  <UserProfile/>
-        </div>
+            <div className="general-container">
+              <UserProfile />
+            </div>
             </Tabs.Panel>}
             {/* {activeView === 'message' && (
               <Chat

--- a/Application/Frontend/pages/accord.tsx
+++ b/Application/Frontend/pages/accord.tsx
@@ -4,15 +4,11 @@ import {
   AppShell,
   Burger,
   Group,
-  Stack,
   Skeleton,
   ScrollArea,
-  Button,
   Text,
   Tooltip,
-  useComputedColorScheme,
   ActionIcon,
-  Container,
   Tabs,
   Switch
 } from '@mantine/core';

--- a/Application/Frontend/pages/api/registration.ts
+++ b/Application/Frontend/pages/api/registration.ts
@@ -49,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         email: email,
         phone: phone,
         createdAt: createdAt,
-        friendsList: ["user1", "user2"] // Example initial friends list
+        friendsList: ["user1", "user2", "user3"] // Example initial friends list
       });
 
       return res.status(200).json({ message: 'Registration successful' });


### PR DESCRIPTION
# Summary of Changes
- Made chat history functional again when clicking on a friend in the Friend's tab component by accounting for the privacy toggle at the `FriendsTab` component mount in the `Accord` application shell
- Changed the profile icon in the `FooterProfile` component to be the profile button from `Clerk`
- Integrated user profiles within chats by loading actual user profiles instead of the default guest fallback
- Removed the `UserButton` component from the application shell menu bar as this has been moved to the `FooterProfile` component

## Key Changes
- The `FriendsTab` component has been modified to reflect the `ChatProps` in the `Chat` component such that `privateChat` and `onMessageExchange` are being passed

## Page Structure
- The FriendsTab component is already integrated within the main application shell

## Documentation
- The `URL` used to display the user profile icon is done via the `imageUrl` parameter from [Clerk](https://clerk.com/docs/references/javascript/user/user)

## Additional Considerations
- The privacy toggle feature is still a work-in-progress as right now users can refresh their page to disable it. The solution to that would be to store the state of the toggle in `localstorage`. However, it actually makes more sense to include the toggle within each chat, and have it specific to each chat as right now its position in the application shell makes it look like it is a global toggle (which it is). This does not make sense as you don't want to have private/public chats with everyone. You want to isolate the state of the toggle to each user.