### PR TITLE
Privacy toggle fix

### DIFF
--- a/Application/accordTypes.ts
+++ b/Application/accordTypes.ts
@@ -35,6 +35,7 @@ export interface ChatProps extends FriendsTabProps {
   receiverIDs: string[];
   channelKey?: string;
   channelName?: string; // Adding channelName as optional
+  captureHistory: boolean; // Renamed and now required
 }
 
 export interface IconProps {
@@ -46,7 +47,7 @@ export interface NewChatModalProps extends NewFriendModalProps {
 }
 
 export interface PrivacySettingsProps {
-  privateChat: boolean;
+  captureHistory: boolean; // Renamed from privateChat
   onMessageExchange: () => void;
 }
 
@@ -76,4 +77,5 @@ export interface TextChannel {
   channelKey: string;
   channelName: string;
   memberIDs: string[];
+  captureHistory: boolean; // Ensure this field is included
 }

--- a/Application/accordTypes.ts
+++ b/Application/accordTypes.ts
@@ -70,6 +70,7 @@ export interface TextChannelItemProps {
   index: number;
   channelName: string;
   numberOfMembers: number;
+  captureHistory: boolean;
   onClick: (id: string) => void;
 }
 

--- a/Application/components/FriendsColumn/FriendsTab.tsx
+++ b/Application/components/FriendsColumn/FriendsTab.tsx
@@ -45,7 +45,7 @@ function goBack() {
  * 
  * @returns The JSX element representing the friends tab section, including a search bar and a list of friends.
  */
-export function FriendsTab({senderUsername, senderID, privateChat, onMessageExchange, lastFetched, setLastFetched }: FriendsTabProps) {
+export function FriendsTab({senderUsername, senderID, captureHistory, onMessageExchange, lastFetched, setLastFetched }: FriendsTabProps) {
     const { user } = useUser();
     const router = useRouter();
     const { list: friends, isLoading } = useFriendList({lastFetched, setLastFetched});
@@ -80,7 +80,7 @@ export function FriendsTab({senderUsername, senderID, privateChat, onMessageExch
           senderID,
           senderUsername,
           receiverIDs: [friendID],
-          privateChat,
+          captureHistory,
           lastFetched,
           setLastFetched,
           onMessageExchange,

--- a/Application/components/Messaging/Chat.tsx
+++ b/Application/components/Messaging/Chat.tsx
@@ -26,24 +26,24 @@ export function Chat({
   senderID,
   senderUsername,
   receiverIDs,
-  privateChat,
+  captureHistory, // Renamed from privateChat
   lastFetched,
   setLastFetched,
   onMessageExchange,
-  channelKey, // Keep the channelKey as it is
-  channelName, // New channelName prop
+  channelKey,
+  channelName,
 }: ChatProps) {
   return (
     <MessagingInterface
       senderID={senderID}
       senderUsername={senderUsername}
       receiverIDs={receiverIDs}
-      privateChat={privateChat}
+      captureHistory={captureHistory}
       lastFetched={lastFetched}
       setLastFetched={setLastFetched}
       onMessageExchange={onMessageExchange}
       channelKey={channelKey}
-      channelName={channelName} // Pass the channelName to the MessagingInterface
+      channelName={channelName}
     />
   );
 }

--- a/Application/components/Messaging/MessageDropdown.tsx
+++ b/Application/components/Messaging/MessageDropdown.tsx
@@ -26,7 +26,7 @@ import { useUser } from '@clerk/nextjs';
  * @returns {JSX.Element} A dropdown menu with options to edit or delete a message, 
  *                        enhanced with conditional tooltips based on chat privacy settings.
  */
-export function MessageDropdown({ privateChat, clientID, onDelete }: MessageDropdownProps) {
+export function MessageDropdown({ captureHistory, clientID, onDelete }: MessageDropdownProps) {
   const { user } = useUser();
   const [userID, setUserID] = useState<string | null>(null);
   const [readyToDelete, setReadyToDelete] = useState(false);
@@ -72,20 +72,11 @@ export function MessageDropdown({ privateChat, clientID, onDelete }: MessageDrop
       </Menu.Target>
 
       <Menu.Dropdown>
-        <Menu.Label>General</Menu.Label>
-        <Menu.Item
-          leftSection={<IconCursorText style={{ width: rem(14), height: rem(14) }} stroke={1} />}
-        >
-          Edit Message
-        </Menu.Item>
-
-        <Menu.Divider />
-
         <Menu.Label>Danger zone</Menu.Label>
-        <MenuItemWithOptionalTooltip privateChat={privateChat} onDelete={onDelete}>
+        <MenuItemWithOptionalTooltip privateChat={captureHistory} onDelete={onDelete}>
           <Menu.Item
             color="red"
-            disabled={privateChat || !myMessage} // If it is not my message, I can't delete it!
+            disabled={!captureHistory || !myMessage} // If it is not my message, I can't delete it!
             leftSection={<IconTrash style={{ width: 14, height: 14 }} />}
             onClick={onDelete}
           >

--- a/Application/components/Messaging/MessagingInterface.tsx
+++ b/Application/components/Messaging/MessagingInterface.tsx
@@ -199,7 +199,7 @@ export function MessagingInterface({
   
       // IMPORTANT: Every time a new message is sent, we are also overwriting the chat history in the database.
       // We are doing this to ensure that the chat history is always up to date.
-      if (!captureHistory) {
+      if (captureHistory) {
         try {
           fetch('/api/update-message-history', {
             method: 'POST', // We are sending messages to the server, so we need to use the POST method. Sensitive data.

--- a/Application/components/Messaging/MessagingInterface.tsx
+++ b/Application/components/Messaging/MessagingInterface.tsx
@@ -9,7 +9,6 @@ import { ChatProps, MessageProps, DisplayedMessageProps } from "@/accordTypes";
 import { useUser } from '@clerk/nextjs';
 import { generateHash } from "@/utility";
 
-
 /**
  * Provides a comprehensive chat interface for real-time messaging within the application.
  * This component integrates with Ably's real-time messaging service to manage and display interactive chat functionalities,
@@ -26,7 +25,7 @@ import { generateHash } from "@/utility";
  * - senderUsername: Username of the message sender.
  * - senderID: Unique identifier of the message sender.
  * - receiverIDs: Array of identifiers for the message recipients, supporting group chat functionality.
- * - privateChat: Boolean flag to indicate whether the chat is private, affecting chat history management.
+ * - captureHistory: Boolean flag to indicate whether the chat is private, affecting chat history management.
  * - onMessageExchange: Callback function triggered on message send or receive, facilitating additional privacy controls.
  *
  * The component's design ensures a seamless chat experience, with features like message grouping by sender,
@@ -41,7 +40,7 @@ export function MessagingInterface({
   senderUsername,
   senderID,
   receiverIDs,
-  privateChat,
+  captureHistory,
   onMessageExchange,
   channelKey: providedChannelKey,
   channelName, // Accept the channelName here
@@ -91,7 +90,7 @@ export function MessagingInterface({
         const incomingMessage: DisplayedMessageProps = {
           id: id,
           clientID: clientID, // Get the clientID of the user who sent the message. This is used to ensure that users can only delete their messages.
-          privateChat: privateChat,
+          captureHistory: captureHistory,
           onMessageExchange: onMessageExchange,
           username: messageData.name,
           message: text,
@@ -152,7 +151,7 @@ export function MessagingInterface({
   // Always fetch history from MongoDB.
     useEffect(() => {
       const fetchHistory = async () => {
-        // Always try to fetch from MongoDB upon component mounting or updates related to channel and privateChat state
+        // Always try to fetch from MongoDB upon component mounting or updates related to channel and captureHistory state
         await fetchMongoDBHistory();
       };
     
@@ -176,7 +175,7 @@ export function MessagingInterface({
     const outgoingMessage = {
       id: tempId, // this needs to be replaced with the real one once it is known. This is done to satisfy TypeScript
       clientID: senderID, // This is OUR client id with respect to our presence in the text channel.
-      privateChat: privateChat, // Bringing these two privacy features down to the message level unlocks immense possibilities for end-to-end privacy.
+      captureHistory: captureHistory, // Bringing these two privacy features down to the message level unlocks immense possibilities for end-to-end privacy.
       onMessageExchange: onMessageExchange,
       username: senderUsername,
       message: messageText,
@@ -200,7 +199,7 @@ export function MessagingInterface({
   
       // IMPORTANT: Every time a new message is sent, we are also overwriting the chat history in the database.
       // We are doing this to ensure that the chat history is always up to date.
-      if (!privateChat) {
+      if (!captureHistory) {
         try {
           fetch('/api/update-message-history', {
             method: 'POST', // We are sending messages to the server, so we need to use the POST method. Sensitive data.
@@ -272,7 +271,7 @@ export function MessagingInterface({
           <Message
             clientID={message.clientID} // Get the clientID of the user who sent the message. This is used to ensure that users can only delete their messages.
             id={message.id}
-            privateChat={privateChat}
+            captureHistory={captureHistory}
             onMessageExchange={onMessageExchange}
             username={message.username}
             message={message.message}
@@ -292,7 +291,7 @@ export function MessagingInterface({
           <Message
             clientID={message.clientID}
             id={message.id}
-            privateChat={privateChat}
+            captureHistory={captureHistory}
             onMessageExchange={onMessageExchange}
             username={message.username}
             message={message.message}

--- a/Application/components/Messaging/NewTextChannelModal.tsx
+++ b/Application/components/Messaging/NewTextChannelModal.tsx
@@ -1,5 +1,16 @@
 import { useDisclosure } from '@mantine/hooks';
-import { Modal, Tooltip, ActionIcon, Text, MultiSelect, Stack, Group, Button, useMantineTheme, TextInput } from '@mantine/core';
+import {
+  Modal,
+  Tooltip,
+  ActionIcon,
+  Text,
+  MultiSelect,
+  Stack, Group,
+  Button,
+  useMantineTheme,
+  TextInput,
+  SegmentedControl 
+} from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { useCache } from '@/contexts/queryCacheContext';
@@ -42,6 +53,7 @@ export function NewTextChannelModal() {
   const [errorMessages, setErrorMessages] = useState({ channelName: '', members: '', admins: '' });
   const [senderID, setSenderID] = useState<string>('');
   const friends = useFriendList({lastFetched, setLastFetched});
+  const [captureHistory, setcaptureHistory] = useState(true); // On by default
   
   useEffect(() => {
     if (user && user.username && user.id) {
@@ -54,6 +66,10 @@ export function NewTextChannelModal() {
     value: friend.id,
     label: friend.username,
   }));
+
+  const handlePrivacyModeChange = (value: string) => {
+    setcaptureHistory(value === 'Capture Message History');
+  };
 
   useEffect(() => {
     // Filter out any selected admins who are not in the updated selected friends list
@@ -89,6 +105,7 @@ export function NewTextChannelModal() {
             memberIDs: [senderID, ...selectedFriends],
             adminIDs: selectedAdmins,
             ownerID: senderID,
+            captureHistory,
           }),
         });
   
@@ -175,6 +192,13 @@ export function NewTextChannelModal() {
           value={selectedAdmins}
           data={friendOptions.filter(option => selectedFriends.includes(option.value))}
           onChange={setSelectedAdmins}
+        />
+        <SegmentedControl
+          data={['Capture Message History', 'Private Mode']}
+          value={captureHistory ? 'Capture Message History' : 'Private Mode'}
+          onChange={handlePrivacyModeChange}
+          transitionDuration={500}
+          transitionTimingFunction="linear"
         />
         <Button
           fullWidth

--- a/Application/components/Messaging/NewTextChannelModal.tsx
+++ b/Application/components/Messaging/NewTextChannelModal.tsx
@@ -118,6 +118,7 @@ export function NewTextChannelModal() {
           setSelectedFriends([]);
           setSelectedAdmins([]);
           setErrorMessages({ channelName: '', members: '', admins: '' });
+          setcaptureHistory(true); // Reset to default (on by default)
           close(); // Close the modal
         } else if (response.status === 409) {
           // Chat already exists, so we need to handle this by prompting the user to change the chat name/members

--- a/Application/components/Server/MemberList.tsx
+++ b/Application/components/Server/MemberList.tsx
@@ -12,7 +12,7 @@ const generateHash = (input: string) => {
   return createHash('sha256').update(input).digest('hex');
 };
 
-export function MemberList({isAdmin, chatID}: any) {
+export function MemberList({isAdmin, chatID, isView}: any) {
   // Hardcoded member list
   const [membersList, setMembersList] = useState<string[]>([]);
   const [membersIDList, setMembersIDList] = useState<string[]>([]);
@@ -23,7 +23,6 @@ export function MemberList({isAdmin, chatID}: any) {
   const [friendUsername, setFriendUsername] = useState('');
   const [searchResult, setSearchResult] = useState<number | null>(null);
   const [isAdmin1, setIsADmin] = useState(isAdmin);
-  const [isView, setIsView] = useState(false);
   const { user } = useUser();
 
   const removeMember = async(member: String, index: any) =>{
@@ -175,9 +174,6 @@ export function MemberList({isAdmin, chatID}: any) {
           console.error('Error fetching member list:', error);
         }
       };
-      if(channelKeyToCheck !== ""){
-        setIsView(true);
-      }
       setChannelKeyToCheck(channelKey); 
       createErrorMessage();
       setChannelKey(chatID)
@@ -197,13 +193,12 @@ export function MemberList({isAdmin, chatID}: any) {
       <Text fw={500} className="text-xl" component="span" size="xl">
         All members
       </Text>
-      <Text>{chatID}</Text>
       {membersList.map((member, index) => (
         <div>
           {/* <Text>{member}</Text> */}
           <Menu shadow="md" position="left" width={225} withArrow >
               <Menu.Target>
-                  <Button fullWidth variant="gradient">
+                  <Button style={{width: "215px"}} variant="gradient">
                       <Group py="10">
                           {/* <Avatar alt={`Member ${index + 1}`} radius="xl" /> */}
                           <Text>{member}</Text>
@@ -225,16 +220,16 @@ export function MemberList({isAdmin, chatID}: any) {
             </Menu>
         </div>
       ))}
-      {isView &&<Button
+      <Button
         onClick={open}
         variant="gradient"
+        style={{width: "215px"}}
         leftSection={<IconPlus style={{ width: rem(18)  , height: rem(18) }}/>}
       >
         <Group py="10">
           <Text size="sm">Add member</Text>
         </Group>
       </Button>
-      }   
       <Modal
         centered
         opened={opened}

--- a/Application/components/TextChannels/TextChannelItem.tsx
+++ b/Application/components/TextChannels/TextChannelItem.tsx
@@ -6,9 +6,9 @@ import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { TextChannelItemProps } from '@/accordTypes';
 import classes from './TextChannelItem.module.css';
 
-export const TextChannelItem: React.FC<TextChannelItemProps> = ({ id, index, channelName, numberOfMembers, onClick }) => {
+export const TextChannelItem: React.FC<TextChannelItemProps> = ({ id, index, channelName, numberOfMembers, captureHistory, onClick }) => {
   const symbol = channelName.substring(0, 2).toUpperCase(); // Generate symbol from channelName
-
+  
   return (
     <Draggable key={id} index={index} draggableId={id}>
       {(provided, snapshot) => (
@@ -23,7 +23,7 @@ export const TextChannelItem: React.FC<TextChannelItemProps> = ({ id, index, cha
           <div>
             <Text>{channelName}</Text>
             <Text c="dimmed" size="sm">
-              {numberOfMembers} members
+              {numberOfMembers} members {captureHistory ? '' : '• Private'}
             </Text>
           </div>
         </div>

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -69,28 +69,32 @@ export function TextChannels() {
     }
   }, [user]); // Dependency array ensures this runs whenever `user` changes
 
-  const fetchUserChats = async () => {
-    if (!userID) return; // Ensure userID is available
-  
-    try {
-      const response = await fetch('/api/get-user-text-channels', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ userID: userID })
-      });
-  
-      if (response.ok) {
-        const { textChannels } = await response.json();
-        setTextChannels(textChannels);
-      } else {
-        console.error('Failed to fetch chat channels');
+  useEffect(() => {
+    const fetchUserChats = async () => {
+      if (!userID) return; // Ensure userID is available
+    
+      try {
+        const response = await fetch('/api/get-user-text-channels', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ userID: userID })
+        });
+    
+        if (response.ok) {
+          const { textChannels } = await response.json();
+          setTextChannels(textChannels);
+        } else {
+          console.error('Failed to fetch chat channels');
+        }
+      } catch (error) {
+        console.error('Error fetching chat channels:', error);
       }
-    } catch (error) {
-      console.error('Error fetching chat channels:', error);
-    }
-  };
+    };
+
+    fetchUserChats();
+  }, [userID]); // This useEffect runs only when userID changes, which should only happen when the user logs in or their user object is fetched initially.
 
   const onChannelClick = (channelKey: string) => {
     // Find the channel details from the state
@@ -125,8 +129,6 @@ export function TextChannels() {
       onClick={onChannelClick} // Passing the click handler
     />
   ));
-
-  fetchUserChats();
 
   return (
     <DragDropContext

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -121,6 +121,7 @@ export function TextChannels() {
       index={index}
       channelName={truncateText(item.channelName, 15)}
       numberOfMembers={item.memberIDs.length}
+      captureHistory={item.captureHistory}
       onClick={onChannelClick} // Passing the click handler
     />
   ));

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -107,7 +107,7 @@ export function TextChannels() {
       onMessageExchange: () => {},
       channelKey,
     });
-    setActiveView('chat'); // Switch to chat view
+    setActiveView('textChannel'); // Switch to chat view
   };
 
   // Mapping through the state to create TextChannelItem components

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -93,15 +93,18 @@ export function TextChannels() {
   };
 
   const onChannelClick = (channelKey: string) => {
-    // Directly updating both selectedChannelId and chatProps via the unified context
-    console.log("channel clicked with key: ", channelKey);
-    console.log("userID: ", userID);
-    console.log("senderUsername: ", senderUsername);
+    // Find the channel details from the state
+    const channel = textChannels.find(channel => channel.channelKey === channelKey);
+    if (!channel) {
+      console.error('Channel not found');
+      return;
+    }
+    
     updateContext(channelKey, {
       senderID: userID,
       senderUsername: senderUsername,
-      receiverIDs: [],
-      privateChat: false,
+      receiverIDs: [], // Assuming this needs to be dynamically fetched or set
+      captureHistory: channel.captureHistory, // Use the captureHistory from the channel details
       lastFetched: Date.now(),
       setLastFetched: () => {},
       onMessageExchange: () => {},

--- a/Application/pages/accord.tsx
+++ b/Application/pages/accord.tsx
@@ -63,6 +63,9 @@ export default function Accord() {
   const [chatStarted, setChatStarted] = useState(false);
   const [isAdmin, setIsAdmin] = useState(true);
 
+  const [isView, setIsView] = useState(false);
+  const [asideWidth, setAsideWidth] = useState(0);
+
   console.log("in app shell ", selectedChannelId);
   console.log("Active view: ", activeView);
   
@@ -77,7 +80,14 @@ export default function Accord() {
   useEffect(() => {
     if (activeView === 'chat' && chatProps) {
       // Log to ensure chatProps are as expected
+      setAsideWidth(0)
       console.log(chatProps);
+    }
+    if(activeView === 'textChannel'){
+      setAsideWidth(250)
+    }
+    if(activeView === "friends"){
+      setAsideWidth(0)
     }
   }, [activeView, chatProps]);
 
@@ -101,7 +111,7 @@ export default function Accord() {
             collapsed: { mobile: !mobileOpened, desktop: !desktopOpened },
           }}
           padding="md"
-          aside={{ width: 250, breakpoint: 'sm' }}
+          aside={{ width: asideWidth, breakpoint: 'sm' }}
         >
           <AppShell.Header>
             <Group justify="space-between" className="center" px="md">
@@ -158,14 +168,13 @@ export default function Accord() {
               setLastFetched={setLastFetched}
             />
           )}
-          {activeView === 'chat' && chatProps && (
+          {(activeView === 'chat' || activeView === 'textChannel') && chatProps && (
             <Chat {...chatProps} />
           )}
           </AppShell.Main>
-          <AppShell.Aside p="md" component={ScrollArea}>
-            <Text>{selectedChannelId}</Text>
+          {activeView === 'textChannel' && <AppShell.Aside p="md" component={ScrollArea}>
             <MemberList isAdmin = {isAdmin} chatID = {selectedChannelId}/>
-          </AppShell.Aside>
+          </AppShell.Aside>}
         </AppShell>
       </Tabs>
     </ActiveViewProvider>

--- a/Application/pages/accord.tsx
+++ b/Application/pages/accord.tsx
@@ -120,16 +120,7 @@ export default function Accord() {
                 <Burger opened={desktopOpened} onClick={toggleDesktop} visibleFrom="sm" size="sm" />
                 <Logo />
               </Group>
-              <Group>
-                <Switch
-                  defaultChecked
-                  color="gray" // May not be the best color choice, but it looks better than orange
-                  label="Private mode"
-                  onChange={(event) => !chatStarted && setPrivateMode(event.currentTarget.checked)}
-                  disabled={chatStarted}  // Disable the switch if the chat has started
-                />
-                <ColorSchemeToggle/>
-              </Group>
+              <ColorSchemeToggle/>
             </Group>
           </AppShell.Header>
           <AppShell.Navbar p="md">
@@ -162,7 +153,7 @@ export default function Accord() {
             <FriendsTab
               senderUsername={sender}
               senderID={senderID}
-              privateChat={privateMode}
+              captureHistory={true} // DMs are never private. That feature is reserved for text channels.
               onMessageExchange={onMessageExchange}
               lastFetched={lastFetched}
               setLastFetched={setLastFetched}

--- a/Application/pages/accord.tsx
+++ b/Application/pages/accord.tsx
@@ -163,6 +163,7 @@ export default function Accord() {
           )}
           </AppShell.Main>
           <AppShell.Aside p="md" component={ScrollArea}>
+            <Text>{selectedChannelId}</Text>
             <MemberList isAdmin = {isAdmin} chatID = {selectedChannelId}/>
           </AppShell.Aside>
         </AppShell>

--- a/Application/pages/api/new-chat.ts
+++ b/Application/pages/api/new-chat.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // That means that we can just not pass in channelName, adminIDs and ownerID to indicate that we're creating a DM.
     // Since we may no longer pass an ownerID, we need to make sure that memberIDs includes the sender ID in the front end
     // as it won't make sense to pass an ownerID for DMs. After all, who owns a DM?
-    const { channelName, memberIDs, adminIDs, ownerID } = req.body;
+    const { channelName, memberIDs, adminIDs, ownerID, captureHistory } = req.body;
     let client: MongoClient | null = null;
 
     try {
@@ -38,6 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           ownerID: ownerID,
           memberIDs: memberIDs,
           adminIDs,
+          captureHistory, // This is a feature unique to text channels. We always capture history in DMs.
           messageHistory: [] // Initialize with an empty message history
         };
       } else { // Creating a DM


### PR DESCRIPTION
## Summary of Changes
1. `removed` privacy toggle from the navbar in the application shell
2. `migrated` the privacy toggle to a `SegmentedControl` component within the `Create text channel` modal so chat owners can specify whether a text channel will be private upon channel creation. This means that users can no longer jailbreak the privacy toggle as they could before by refreshing, as the state of the toggle is now stored within our MongoDB database under a field called `captureHistory` that is added to every text channel. If it is true, we upload the chat history to our MongoDB database. Otherwise, we just rely on real-time SMS via `Ably`.
3. Conducted extensive ad-hoc testing for the private and non-private text channels and confirmed that messages save or do not save accordingly. It is ensured that all direct messages are non-private.
4. Patched an issue where text channels would auto sort themselves by date even after the user sorts them themselves (the draggable text channel feature is now fully functional and robust!)

## Features In-Depth
- Channels marked as `private` will not capture message history, and leaving the text channel by clicking on a different text channel and clicking back on the private channel will wipe all message history on your view. The user on the receiving end will experience the same outcome if they click on a different text channel and come back, or if they refresh their browser
- Channels `not marked` as `private` will capture message history. The messages will persist across channel changes and upon logging in / logging out / refreshing your browser / ending the session
- All direct messages capture history and there is no way to disable that as we are assigning the `private mode` feature as an exclusive feature to text channels

## Visual Summary of Changes
<img width="1440" alt="Screenshot 2024-04-08 at 5 12 14 PM" src="https://github.com/ColinLefter/Accord/assets/68645918/1315d3dc-19a0-43c9-8e82-dc88724e6dbf">
<img width="1440" alt="Screenshot 2024-04-08 at 5 14 08 PM" src="https://github.com/ColinLefter/Accord/assets/68645918/6371e168-e399-4a20-bc74-e9165a7dbe69">
<img width="1440" alt="Screenshot 2024-04-08 at 5 14 44 PM" src="https://github.com/ColinLefter/Accord/assets/68645918/5a648c19-f5d3-490c-8674-723452484999">
<img width="1440" alt="Screenshot 2024-04-08 at 5 13 39 PM" src="https://github.com/ColinLefter/Accord/assets/68645918/c01b663e-4ac7-4f84-a2f5-1ff4ef497ee3">

![image](https://github.com/ColinLefter/Accord/assets/68645918/8ffc789f-e250-4af2-9ea0-df4ffb3ccb59)