### PR TITLE
Patched critical message deletion malfunction

### DIFF
--- a/Application/components/Messaging/MessageDropdown.tsx
+++ b/Application/components/Messaging/MessageDropdown.tsx
@@ -76,7 +76,7 @@ export function MessageDropdown({ captureHistory, clientID, onDelete }: MessageD
         <MenuItemWithOptionalTooltip privateChat={captureHistory} onDelete={onDelete}>
           <Menu.Item
             color="red"
-            disabled={!captureHistory || !myMessage} // If it is not my message, I can't delete it!
+            disabled={!myMessage} // If it is not my message, I can't delete it!
             leftSection={<IconTrash style={{ width: 14, height: 14 }} />}
             onClick={onDelete}
           >


### PR DESCRIPTION
## Summary of changes
- A simple one-line hotfix to solve the issue of the message deletion button being permanently disabled