### PR TITLE
Menu fix

### DIFF
--- a/Application/accordTypes.ts
+++ b/Application/accordTypes.ts
@@ -79,6 +79,7 @@ export interface TextChannelItemProps {
   numberOfMembers: number;
   captureHistory: boolean;
   onClick: (id: string) => void;
+  isSelected: boolean;
 }
 
 export interface TextChannel {
@@ -86,5 +87,10 @@ export interface TextChannel {
   channelName: string;
   memberIDs: string[];
   adminIDs: string[];
+  ownerID: string;
   captureHistory: boolean; // Ensure this field is included
+}
+
+export interface ChannelLoadingProps {
+  numChannels: number;
 }

--- a/Application/components/FriendsColumn/FriendsColumn.module.css
+++ b/Application/components/FriendsColumn/FriendsColumn.module.css
@@ -1,0 +1,8 @@
+.friendItem {
+  transition: background-color 0.05s ease-in-out;
+  cursor: pointer;
+}
+
+.friendItem:hover {
+  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}

--- a/Application/components/FriendsColumn/FriendsTab.tsx
+++ b/Application/components/FriendsColumn/FriendsTab.tsx
@@ -23,7 +23,9 @@ import { FriendsLoading } from '@/components/FriendsColumn/FriendsLoading';
 import { useChannel } from "ably/react";
 import { getSystemsChannelID} from "@/utility";
 import { useActiveView } from '@/contexts/activeViewContext';
-import { useChat } from '@/contexts/chatContext'
+import { useChat } from '@/contexts/chatContext';
+import classes from './FriendsColumn.module.css';
+import cx from 'clsx';
 
 // Function to call to go back to the last previous URL
 function goBack() {
@@ -84,6 +86,7 @@ export function FriendsTab({senderUsername, senderID, captureHistory, onMessageE
           lastFetched,
           setLastFetched,
           onMessageExchange,
+          isAdmin: false // This is not a property for DMs so just pass false as we won't render the right tab anyway
         });
         setActiveView('chat'); // Ensure we are setting the active view to 'chat'
       };
@@ -139,12 +142,19 @@ export function FriendsTab({senderUsername, senderID, captureHistory, onMessageE
                     </Paper>
                 ) : (
                     filteredFriendList.map((friend, index) => (
-                        <Paper shadow="xs" p="xs" radius="md" key={`friend-${index}`} onClick={() => handleFriendClick(friend.username, friend.id)}>
-                            <Group py="10">
-                                <Avatar alt={`Friend ${friend.username}`} radius="xl"/>
-                                <Text size="sm">{friend.username}</Text>
-                            </Group>
-                        </Paper>
+                        <Paper
+                            shadow="xs"
+                            p="xs"
+                            radius="md"
+                            key={`friend-${index}`}
+                            onClick={() => handleFriendClick(friend.username, friend.id)}
+                            className={cx(classes.friendItem)} // Apply the hover style
+                        >
+                        <Group py="10">
+                            <Avatar alt={`Friend ${friend.username}`} radius="xl" />
+                            <Text size="sm">{friend.username}</Text>
+                        </Group>
+                    </Paper>
                     ))
                 )
             )}

--- a/Application/components/FriendsColumn/FriendsTab.tsx
+++ b/Application/components/FriendsColumn/FriendsTab.tsx
@@ -4,7 +4,6 @@ import {
     Group,
     Text,
     TextInput,
-    TextInputProps,
     ActionIcon,
     useMantineTheme,
     Stack,
@@ -12,17 +11,12 @@ import {
     Center
 } from '@mantine/core';
 import { IconSearch, IconArrowRight } from '@tabler/icons-react';
-import { FormEvent, useEffect, useState } from "react";
-import Link from "next/link";
-import { useRouter } from 'next/router';
-import { useUser } from '@clerk/nextjs';
-import { Chat } from '@/components/Messaging/Chat';
+import { useState } from "react";
 import { useFriendList } from '@/hooks/useFriendList';
 import { FriendsTabProps } from '@/accordTypes';
 import { FriendsLoading } from '@/components/FriendsColumn/FriendsLoading';
 import { useChannel } from "ably/react";
 import { getSystemsChannelID} from "@/utility";
-import { useActiveView } from '@/contexts/activeViewContext';
 import { useChat } from '@/contexts/chatContext';
 import classes from './FriendsColumn.module.css';
 import cx from 'clsx';
@@ -48,15 +42,11 @@ function goBack() {
  * @returns The JSX element representing the friends tab section, including a search bar and a list of friends.
  */
 export function FriendsTab({senderUsername, senderID, captureHistory, onMessageExchange, lastFetched, setLastFetched }: FriendsTabProps) {
-    const { user } = useUser();
-    const router = useRouter();
     const { list: friends, isLoading } = useFriendList({lastFetched, setLastFetched});
     const [searchQuery, setSearchQuery] = useState<string>('');
-    const [receiverUsername, setreceiverUsername] = useState<string>('');
-    const [receiverID, setReceiverID] = useState<string>('');
     const { updateContext, setActiveView } = useChat();
     
-    const { channel } = useChannel(getSystemsChannelID(), (message) => {
+    useChannel(getSystemsChannelID(), (message) => {
         if (message.name === "friend-request-accepted") {
           const [senderId, receiverId] = message.data.split("-");
           if (senderId === senderID || receiverId === senderID) {

--- a/Application/components/Messaging/MessageDropdown.tsx
+++ b/Application/components/Messaging/MessageDropdown.tsx
@@ -7,6 +7,7 @@ import {
 import { MessageDropdownProps } from '@/accordTypes';
 import { useState, useEffect, forwardRef, ReactNode } from 'react';
 import { useUser } from '@clerk/nextjs';
+import { useChat } from '@/contexts/chatContext';
 
 /**
  * Renders a dropdown menu associated with a message, providing options to edit or delete the message. 
@@ -31,8 +32,8 @@ export function MessageDropdown({ captureHistory, clientID, onDelete, isAdmin  }
   const [userID, setUserID] = useState<string | null>(null);
   const [readyToDelete, setReadyToDelete] = useState(false);
   const textColor = useComputedColorScheme() === 'dark' ? "white" : "black";
-  const [isAdmin1, setIsAdmin1] = useState(true)
   const [deleteable, setDeleteable] = useState(true)
+  const { chatProps } = useChat();
 
   // Effect to check for user id availability
   useEffect(() => {
@@ -84,7 +85,7 @@ export function MessageDropdown({ captureHistory, clientID, onDelete, isAdmin  }
         <MenuItemWithOptionalTooltip privateChat={captureHistory} onDelete={onDelete}>
           <Menu.Item
             color="red"
-            disabled={!myMessage} // If it is not my message, I can't delete it!
+            disabled={!(myMessage || chatProps?.isAdmin)} // If it is not my message, I can't delete it! But if I am admin, I can even if it's not mine
             leftSection={<IconTrash style={{ width: 14, height: 14 }} />}
             onClick={onDelete}
           >

--- a/Application/components/TextChannels/ChannelLoading.tsx
+++ b/Application/components/TextChannels/ChannelLoading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton, Stack } from "@mantine/core";
+import { ChannelLoadingProps } from "@/accordTypes";
+
+export function ChannelLoading({numChannels } : ChannelLoadingProps) {
+  // Create an array to hold the loading skeletons
+  const loadingSkeletons = [];
+
+  // Use a for loop to generate the specified number of skeleton groups
+  for (let i = 0; i < numChannels; i++) {
+    const skeletonGroup = (
+      <Stack key={`skeleton-group-${i}`} gap="0">
+        <Skeleton height={8} radius="xl" />
+        <Skeleton height={8} mt={6} radius="xl" />
+        <Skeleton height={8} mt={6} width="70%" radius="xl" />
+      </Stack>
+    );
+    loadingSkeletons.push(skeletonGroup);
+  }
+
+  return (
+    <Stack gap="xl">
+      {loadingSkeletons}
+    </Stack>
+  );
+}

--- a/Application/components/TextChannels/TextChannelItem.module.css
+++ b/Application/components/TextChannels/TextChannelItem.module.css
@@ -7,6 +7,14 @@
   margin-bottom: var(--mantine-spacing-sm);
 }
 
+.item:hover {
+  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
+.itemSelected {
+  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+}
+
 .itemDragging {
   box-shadow: var(--mantine-shadow-sm);
 }

--- a/Application/components/TextChannels/TextChannelItem.tsx
+++ b/Application/components/TextChannels/TextChannelItem.tsx
@@ -5,16 +5,21 @@ import { useListState } from '@mantine/hooks';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { TextChannelItemProps } from '@/accordTypes';
 import classes from './TextChannelItem.module.css';
+import { useChat } from '@/contexts/chatContext';
 
-export const TextChannelItem: React.FC<TextChannelItemProps> = ({ id, index, channelName, numberOfMembers, captureHistory, onClick }) => {
+export const TextChannelItem: React.FC<TextChannelItemProps> = ({ id, index, channelName, numberOfMembers, captureHistory, isSelected, onClick }) => {
   const symbol = channelName.substring(0, 2).toUpperCase(); // Generate symbol from channelName
+  const { selectedChannelId } = useChat();
   
   return (
     <Draggable key={id} index={index} draggableId={id}>
       {(provided, snapshot) => (
         <div
           onClick={() => onClick(id)}
-          className={cx(classes.item, { [classes.itemDragging]: snapshot.isDragging })}
+          className={cx(classes.item, {
+            [classes.itemDragging]: snapshot.isDragging,
+            [classes.itemSelected]: isSelected && selectedChannelId !== ''
+          })}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           ref={provided.innerRef}

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -71,7 +71,7 @@ export function TextChannels() {
           break;
         case "removed-from-text-channel":
           fetchUserChats();
-          setActiveView('friends');
+          message.data.userID === userID && setActiveView('friends');
           break;
         default:
           break;

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -71,7 +71,7 @@ export function TextChannels() {
           break;
         case "removed-from-text-channel":
           fetchUserChats();
-          message.data.userID === userID && setActiveView('friends');
+          message.data.removedMemberID === userID && setActiveView('friends');
           break;
         default:
           break;

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -1,17 +1,14 @@
-import cx from 'clsx';
-import { rem, Text, Stack } from '@mantine/core';
-import { IconGripVertical } from '@tabler/icons-react';
-import { useListState } from '@mantine/hooks';
-import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import { Text, Center } from '@mantine/core';
+import { DragDropContext, Droppable } from '@hello-pangea/dnd';
 import { TextChannelItem } from "@/components/TextChannels/TextChannelItem"
-import { useUser, UserProfile } from '@clerk/nextjs';
-import { formatDate, truncateText } from "@/utility"
+import { useUser } from '@clerk/nextjs';
+import { truncateText } from "@/utility"
 import { TextChannel } from "@/accordTypes";
-import { useChannelContext } from "@/contexts/channelContext";
 import { useChat } from '@/contexts/chatContext';
 import { useChannel } from "ably/react";
 import { getSystemsChannelID} from "@/utility";
 import { useEffect, useState, useCallback } from 'react';
+import { ChannelLoading } from "@/components/TextChannels/ChannelLoading";
 
 function reorder(list: TextChannel[], startIndex: number, endIndex: number): TextChannel[] {
   const result = Array.from(list);
@@ -62,57 +59,70 @@ export function TextChannels() {
   const  [ senderUsername, updateSenderUsername ] = useState<string>('');
   const [textChannels, setTextChannels] = useState<TextChannel[]>([]);
   const { updateContext, setActiveView } = useChat();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [selectedChannelId, setSelectedChannelId] = useState('');
 
   useChannel(getSystemsChannelID(), (message) => {
-    // Listen for a specific message event to trigger the refresh
-    if (message.name === "text-channel-created" || message.name === "removed-from-text-channel") {
-      fetchUserChats(); // Call fetchUserChats to refresh the channels list
-    }
-  });
+    const handleChannelMessage = (message: string) => {
+      switch (message) {
+        case "text-channel-created":
+          fetchUserChats();
+          break;
+        case "removed-from-text-channel":
+          fetchUserChats();
+          setActiveView('friends');
+          break;
+        default:
+          break;
+      }
+  }});
 
-  useEffect(() => {
-    if (user && user.id && user.username) {
+  const fetchUserChats = useCallback(async () => {
+    setIsLoading(true); // Start loading
+    if (!userID) {
+        setIsLoading(false);
+        return;
+    }
+
+    try {
+        const response = await fetch('/api/get-user-text-channels', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ userID: userID })
+        });
+
+        if (response.ok) {
+            const { textChannels } = await response.json();
+            setTextChannels(textChannels);
+        } else {
+            console.error('Failed to fetch chat channels');
+        }
+    } catch (error) {
+        console.error('Error fetching chat channels:', error);
+    } finally {
+        setIsLoading(false); // End loading regardless of the outcome
+    }
+}, [userID]);
+
+useEffect(() => {
+  if (user && user.id && user.username) {
       setUserID(user.id);
       updateSenderUsername(user.username);
-    }
-  }, [user]); // Dependency array ensures this runs whenever `user` changes
-
-  // Wrap fetchUserChats inside useCallback to avoid recreating the function on every render
-  const fetchUserChats = useCallback(async () => {
-    if (!userID) return; // Ensure userID is available
-  
-    try {
-      const response = await fetch('/api/get-user-text-channels', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ userID: userID })
-      });
-  
-      if (response.ok) {
-        const { textChannels } = await response.json();
-        setTextChannels(textChannels);
-      } else {
-        console.error('Failed to fetch chat channels');
-      }
-    } catch (error) {
-      console.error('Error fetching chat channels:', error);
-    }
-  }, [userID]); // Add userID to the dependency array of useCallback
-
-  useEffect(() => {
-    fetchUserChats();
-  }, [userID, fetchUserChats]); // This useEffect depends on userID AND fetchUserChats
+      fetchUserChats(); // Fetch text channels once the user ID is set
+  }
+}, [user, fetchUserChats]);
 
   const onChannelClick = (channelKey: string) => {
+    setSelectedChannelId(channelKey);
     // Find the channel details from the state
     const channel = textChannels.find(channel => channel.channelKey === channelKey);
     if (!channel) {
       console.error('Channel not found');
       return;
     }
-    const isAdmin = channel?.adminIDs.includes(userID);
+    const isAdmin = channel.adminIDs.includes(userID) || channel.ownerID === userID;
     
     updateContext(channelKey, {
       senderID: userID,
@@ -123,10 +133,20 @@ export function TextChannels() {
       setLastFetched: () => {},
       onMessageExchange: () => {},
       channelKey,
-      isAdmin: !!isAdmin // Pass isAdmin flag; !! converts undefined to false if clickedChannel or adminIDs is not found
+      isAdmin: isAdmin
     });
     setActiveView('textChannel'); // Switch to chat view
   };
+
+  if (isLoading) {
+    // Return loading placeholders/skeletons here
+    return <ChannelLoading numChannels={6} />; // Replace this with your actual loading component
+  }
+
+  if (textChannels.length === 0 && !isLoading) {
+      // Render nothing or a message indicating no text channels
+      return <Center><Text>Create a channel to get started.</Text></Center>
+  }
 
   // Mapping through the state to create TextChannelItem components
   const items = textChannels.map((item, index) => (
@@ -138,6 +158,7 @@ export function TextChannels() {
       numberOfMembers={item.memberIDs.length}
       captureHistory={item.captureHistory}
       onClick={onChannelClick} // Passing the click handler
+      isSelected={item.channelKey === selectedChannelId}
     />
   ));
 

--- a/Application/components/TextChannels/TextChannels.tsx
+++ b/Application/components/TextChannels/TextChannels.tsx
@@ -9,6 +9,7 @@ import { useChannel } from "ably/react";
 import { getSystemsChannelID} from "@/utility";
 import { useEffect, useState, useCallback } from 'react';
 import { ChannelLoading } from "@/components/TextChannels/ChannelLoading";
+import { Types } from 'ably'; // This is an example; actual path may vary
 
 function reorder(list: TextChannel[], startIndex: number, endIndex: number): TextChannel[] {
   const result = Array.from(list);
@@ -62,9 +63,9 @@ export function TextChannels() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [selectedChannelId, setSelectedChannelId] = useState('');
 
-  useChannel(getSystemsChannelID(), (message) => {
-    const handleChannelMessage = (message: string) => {
-      switch (message) {
+  useChannel(getSystemsChannelID(), (messageEvent) => {
+    const handleChannelMessage = (message: Types.Message) => {
+      switch (message.name) {
         case "text-channel-created":
           fetchUserChats();
           break;
@@ -75,7 +76,10 @@ export function TextChannels() {
         default:
           break;
       }
-  }});
+    };
+  
+    handleChannelMessage(messageEvent);
+  });
 
   const fetchUserChats = useCallback(async () => {
     setIsLoading(true); // Start loading

--- a/Application/pages/accord.tsx
+++ b/Application/pages/accord.tsx
@@ -44,7 +44,7 @@ export default function Accord() {
   const { lastFetched, setLastFetched } = useCache();
   const [mobileOpened, { toggle: toggleMobile }] = useDisclosure();
   const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
-  const { activeView, setActiveView, chatProps, selectedChannelId } = useChat();
+  const { activeView, setActiveView, chatProps, selectedChannelId, setSelectedChannelId } = useChat();
   // Default is to just display no username. This will never be the case as you can't be here without an account.
   // It just makes more sense to not show something like guestUser to indicate that the user must have an account if they have reached the shell.
   const [sender, setSender] = useState<string>(''); 
@@ -53,7 +53,6 @@ export default function Accord() {
   const [isAdmin, setIsAdmin] = useState(true);
   const [asideWidth, setAsideWidth] = useState(0);
 
-  
   useEffect(() => {
     if (user && user.username && user.id) {
       // Set sender to user's username if user exists and username is not null/undefined
@@ -61,6 +60,13 @@ export default function Accord() {
       setSenderID(user.id);
     }
   }, [user]); // Dependency array ensures this runs whenever `user` changes
+
+  useEffect(() => {
+    // Deselect the current channel when switching to the friends view
+    if (activeView === "friends") {
+      setSelectedChannelId('');
+    }
+  }, [activeView, setSelectedChannelId]);
 
   useEffect(() => {
     if (activeView === 'chat' && chatProps) {


### PR DESCRIPTION
## Summary of Changes
1. `added` ability for admins to delete messages from any user in a text channel while giving non-admins only the ability to delete their own messages
2. `fixed` an issue where text channel owners did not have admin privileges
3. `ensured` real-time view switch to the `friends` tab upon being deleted from a text channel
4. `added` UI styling flourishes: `on-hover` for text channels and friends tab while leaving text channels highlighted upon selection and removing the highlight upon switching back to the friends tab
5. Thoroughly tested all core application features (friend requests, channel creation, direct messages, private mode on/off, admin privileges) and confirmed that all core features work without issue. There is only one known issue that involves message deletion (a special case that will not be patched). See the below for known issues.

## Known Issues
- Message deletion reflects in real-time only for channel owners/admins. It does not reflect for the case when a non-admin deletes their message. A hard refresh needs to be done to see that. The cause is not known as it has not been investigated and will not be investigated due to time constraints.
- The "promote to admin feature" is not working as no implementation exists for it. It just deletes a member as that function is being called for that case as well.

## Other Notes
- The project can be marked as completed as of this pull request. We need to go all-in on M5 and focus our efforts elsewhere as well.