### PR TITLE
Admin Promotion Implemented

### DIFF
--- a/Application/components/Server/MemberList.tsx
+++ b/Application/components/Server/MemberList.tsx
@@ -32,6 +32,7 @@ export function MemberList({ chatID }: any) {
   }, [user]); // Dependency array ensures this runs whenever `user` changes
 
   // onClick function responsible for adminPromotion within the onClick of the button
+  // Replies with a notification regarding to the result of the promotion
   const adminPromotion = async ( index: any, myID: any, channelKey: String, ) => {
     try {
       const promotionID = membersIDList[index]
@@ -45,6 +46,7 @@ export function MemberList({ chatID }: any) {
       });
 
       if (response.ok) {
+        // Switch case to properly send notifications of the result
         switch (response.status) {
           case 200:
             showNotification({

--- a/Application/components/Server/MemberList.tsx
+++ b/Application/components/Server/MemberList.tsx
@@ -31,6 +31,73 @@ export function MemberList({ chatID }: any) {
     }
   }, [user]); // Dependency array ensures this runs whenever `user` changes
 
+  // onClick function responsible for adminPromotion within the onClick of the button
+  const adminPromotion = async ( index: any, myID: any, channelKey: String, ) => {
+    try {
+      const promotionID = membersIDList[index]
+      console.log(promotionID, myID, channelKey); 
+      const response = await fetch('/api/admin-promotion', {
+        method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ promotingID: promotionID, promoterID: myID, channelKey: channelKey }),
+      });
+
+      if (response.ok) {
+        switch (response.status) {
+          case 200:
+            showNotification({
+              title: 'Admin Promotion Success',
+              message: `The user is now an admin of the text channel`,
+              color: 'green',
+            });
+            break;
+          case 201:
+            showNotification ({
+              title: 'Admin Promotion Unsuccessful',
+              message: 'The user is already an admin of the text channel',
+              color: 'red',
+            });
+            break;
+          case 202:
+            showNotification ({
+              title: 'Admin Promotion Unsuccessful',
+              message: 'The user is the owner of the text channel',
+              color: 'red',
+            });
+            break;
+          case 203:
+            showNotification ({
+              title: 'Admin Promotion Unsuccessful',
+              message: 'You cant grant yourself more admin-ness',
+              color: 'red',
+            });
+            break;
+          default:
+            showNotification ({
+              title: 'Uncaught error',
+              message: 'API did not response with a specified status',
+              color: 'yellow',
+            });
+        }
+      } else {
+        showNotification ({
+          title: 'Admin Promotion Unsuccessful',
+          message: 'Admin promotion for the user is unsuccessful - due to uncaught errors',
+          color: 'red',
+        });
+      }
+    } catch (error) {
+      console.log('Failed admin promotion', error);
+      showNotification ({
+        title: 'Caught error',
+        message: 'For some reason, the function did not work properly',
+        color: 'purple',
+      });
+    }
+  }  
+
   const removeMember = async(member: String, index: any) => {
     const memberToRemove = membersIDList[index];
     // No need to generate a newChannelKey here since the backend will handle this
@@ -205,7 +272,7 @@ export function MemberList({ chatID }: any) {
               isAdmin && <Menu.Dropdown>
                 <Menu.Label>Manage User</Menu.Label>
                 <Menu.Item color="green" leftSection={<IconUserUp style={{ width: rem(16)  , height: rem(16) }}/>}>
-                  <Button color='green' c="white" fullWidth onClick={() => removeMember(member, index)}>Promote to Admin</Button>
+                  <Button color='green' c="white" fullWidth onClick={() => adminPromotion(index, myID, channelKey)}>Promote to Admin</Button>
                 </Menu.Item>
 
                 <Menu.Item color="red" leftSection={<IconTrash style={{ width: rem(14)  , height: rem(14) }}/>}>

--- a/Application/pages/api/admin-promotion.ts
+++ b/Application/pages/api/admin-promotion.ts
@@ -2,6 +2,18 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { MongoClient } from 'mongodb';
 import { getMongoDbUri } from '@/lib/dbConfig';
 
+/**
+ * This API communicates with the MongoDB, intakes in promotingID, promoterID, and a channelKey
+ * Searches a channel using the channelKey, searches for the existance of ownership or adminship of the promotingID
+ * Returns message (NOT ERRORS) accordingly:
+ * - 200: the promotingID is not in the adminIDs array - append into the list of admin
+ * - 201: the promotingID is in the adminIDs array - aka is already an admin, and the entry stays the same
+ * - 202: the promotingID is the ownerID - shouldn't be appended to the adminIDs array
+ * - 203: the promotingID is the same as the promoterID - shouldn't be appended to the adminIDs array
+ * @param {NextApiRequest} req The Next.js API request object.
+ * @param {NextApiResponse} res The Next.js API response object.
+ */
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method !== 'POST') {
       return res.status(405).end(`Method ${req.method} Not Allowed`);
@@ -11,7 +23,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const client = new MongoClient(getMongoDbUri());
 
     try {
-
       // Communicate with the server
       await client.connect();
       const db = client.db('Accord');

--- a/Application/pages/api/admin-promotion.ts
+++ b/Application/pages/api/admin-promotion.ts
@@ -19,7 +19,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // Find entries that the member already exists in, or is already the owner of the server
       const promotingIsAdmin = await chatsCollection.findOne({ channelKey : channelKey, adminIDs : promotingID })
-      const promotingIsOwner = await chatsCollection.findOne({ channelKey : channelKey, ownerIDs : promotingID })
+      const promotingIsOwner = await chatsCollection.findOne({ channelKey : channelKey, ownerID : promotingID })
+
+      if ( promoterID == promotingID ) {
+        return res.status(203).json({ message: 'You cant grant yourself more admin-ness' })
+      }
 
       if (promotingIsAdmin) {
         return res.status(201).json({ message: 'The user is already an admin of the text channel'})
@@ -29,11 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(202).json({ message: 'The user is the owner of the text channel'})
       }
 
-      if ( promoterID == promotingID ) {
-        return res.status(203).json({ message: 'You cant grant yourself more admin-ness' })
-      }
-
-      await chatsCollection.updateOne({ channelKey: channelKey}, { $addToSet: { adminID: promotingID }})
+      await chatsCollection.updateOne({ channelKey: channelKey}, { $addToSet: { adminIDs: promotingID }})
       return res.status(200).json({ message: 'Promoted user to admin successfully' });
 
     } catch (error) {

--- a/Application/pages/api/admin-promotion.ts
+++ b/Application/pages/api/admin-promotion.ts
@@ -18,23 +18,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const chatsCollection = db.collection('Chats');
 
       // Find entries that the member already exists in, or is already the owner of the server
-      const promotingIsAdmin = await chatsCollection.findOne({ channelKey : channelKey })
-      const promotingIsOwner = await chatsCollection.findOne({ channelKey : channelKey })
-
+      const promotingIsAdmin = await chatsCollection.findOne({ channelKey : channelKey, adminIDs : promotingID })
+      const promotingIsOwner = await chatsCollection.findOne({ channelKey : channelKey, ownerIDs : promotingID })
 
       if (promotingIsAdmin) {
-        return res.status(201).json({ error: 'The user is already an admin of the text channel'})
+        return res.status(201).json({ message: 'The user is already an admin of the text channel'})
       }
 
       if (promotingIsOwner) {
-        return res.status(202).json({ error: 'The user is the owner of the text channel'})
+        return res.status(202).json({ message: 'The user is the owner of the text channel'})
       }
 
-      if (promoterID == promotingID ) {
-        return res.status(203).json({ error: 'You cant grant yourself more admin-ness' })
+      if ( promoterID == promotingID ) {
+        return res.status(203).json({ message: 'You cant grant yourself more admin-ness' })
       }
 
-      await chatsCollection.updateOne({ channelKey: channelKey}, {$addToSet: { adminsID: promotingID }})
+      await chatsCollection.updateOne({ channelKey: channelKey}, { $addToSet: { adminsID: promotingID }})
       return res.status(200).json({ message: 'Promoted user to admin successfully' });
 
     } catch (error) {

--- a/Application/pages/api/admin-promotion.ts
+++ b/Application/pages/api/admin-promotion.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { MongoClient } from 'mongodb';
+import { getMongoDbUri } from '@/lib/dbConfig';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'POST') {
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+    
+    const { promotingID, promoterID, channelKey } = req.body;
+    const client = new MongoClient(getMongoDbUri());
+
+    try {
+
+      // Communicate with the server
+      await client.connect();
+      const db = client.db('Accord');
+      const chatsCollection = db.collection('Chats');
+
+      // Find entries that the member already exists in, or is already the owner of the server
+      const promotingIsAdmin = await chatsCollection.findOne({ channelKey : channelKey })
+      const promotingIsOwner = await chatsCollection.findOne({ channelKey : channelKey })
+
+
+      if (promotingIsAdmin) {
+        return res.status(201).json({ error: 'The user is already an admin of the text channel'})
+      }
+
+      if (promotingIsOwner) {
+        return res.status(202).json({ error: 'The user is the owner of the text channel'})
+      }
+
+      if (promoterID == promotingID ) {
+        return res.status(203).json({ error: 'You cant grant yourself more admin-ness' })
+      }
+
+      await chatsCollection.updateOne({ channelKey: channelKey}, {$addToSet: { adminsID: promotingID }})
+      return res.status(200).json({ message: 'Promoted user to admin successfully' });
+
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ error: 'Internal server error' });
+    } finally {
+      await client.close();
+    }
+}

--- a/Application/pages/api/admin-promotion.ts
+++ b/Application/pages/api/admin-promotion.ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(203).json({ message: 'You cant grant yourself more admin-ness' })
       }
 
-      await chatsCollection.updateOne({ channelKey: channelKey}, { $addToSet: { adminsID: promotingID }})
+      await chatsCollection.updateOne({ channelKey: channelKey}, { $addToSet: { adminID: promotingID }})
       return res.status(200).json({ message: 'Promoted user to admin successfully' });
 
     } catch (error) {


### PR DESCRIPTION
- `added` a new onClick function, `adminPromotion` within `Components/Server` that takes in information from each of the modal of the member list, and pops a notification for the results of the promotion (or, the failed promotion)
- `added` a new API `admin-promotion.ts` to communicate and facilitate with our database, and process the information to decide either add the ID to the adminIDs array (which keep tracks of the admins in that text channel, sends back a message that display how the promotion was denied, or an error failing to establish connection with the DB / API

---

### Screenshots of the notification in action

![image](https://github.com/ColinLefter/Accord/assets/113058628/c4ed86b2-e9a8-4d15-aa6d-d4d3d6fcfd37)

![image](https://github.com/ColinLefter/Accord/assets/113058628/f74a36d4-cda8-4960-b769-c9a64f5176ab)

![image](https://github.com/ColinLefter/Accord/assets/113058628/69b60f51-9a8e-4d4b-bea0-66e76e39bf21)

![image](https://github.com/ColinLefter/Accord/assets/113058628/40ebe302-1204-44e0-ab4a-7c446d39c2e9)
